### PR TITLE
Completed view all post & view post details #43

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,9 +6,9 @@
     "configurations": [
         {
             "name": "Python: Request Handler",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
-            "program": "./request_handler.py",
+            "program": "./json-server.py",
             "console": "integratedTerminal"
         }
     ]

--- a/json-server.py
+++ b/json-server.py
@@ -1,9 +1,9 @@
 import json
 from http.server import HTTPServer
 from nss_handler import HandleRequests, status
+from views import get_single_post, get_all_posts
 
-from views import get_all_orders, get_single_order, create_order, delete_order
-from views import update_metal, get_all_metals
+
 
 
 class JSONServer(HandleRequests):
@@ -11,12 +11,12 @@ class JSONServer(HandleRequests):
         response_body = ""
         url = self.parse_url(self.path)
 
-        if url["requested_resource"] == "orders":
+        if url["requested_resource"] == "posts":
             if url["pk"] != 0:
-                response_body = get_single_order(url["pk"])
+                response_body = get_single_post(url["pk"])
                 return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
-            response_body = get_all_orders()
+            response_body = get_all_posts()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
         elif url["requested_resource"] == "metals":

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -89,3 +89,9 @@ INSERT INTO Categories ('label') VALUES ('News');
 INSERT INTO Tags ('label') VALUES ('JavaScript');
 INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.com/so/happy');
 
+INSERT INTO Posts (user_id, category_id, title, publication_date, image_url, content, approved)
+VALUES (1, 1, 'First Post', '2024-02-15', 'https://example.com/image1.jpg', 'This is the content of the first post.', 1);
+
+INSERT INTO Posts (user_id, category_id, title, publication_date, image_url, content, approved)
+VALUES (2, 2, 'Second Post', '2024-02-16', 'https://example.com/image2.jpg', 'This is the content of the second post.', 1);
+

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # Rare Server
 <!-- TODO: Add a description of the Rare application -->
+Our client, Rare Publishing, needs a new application built for their readers. Currently, readers can submit new articles through the mail and once month Rare sends out a Zine of articles that the publishers liked the most. They've finally decided that the internet is not a fad and want a new way for readers view posts.
+
+The finished application will give users the ability to submit, update and comment on posts. The posts will also be organized by tags and categories making it easier for the reader to find the posts they are searching for.
+
 
 ## Getting Started:
 1. Run `pipenv shell` to start the virtual environment

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,0 +1,1 @@
+from .post import get_all_posts, get_single_post

--- a/views/post.py
+++ b/views/post.py
@@ -1,0 +1,68 @@
+import sqlite3
+import json
+
+def get_all_posts():
+    # Open a connection to the database
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        # Write the SQL query to get the information you want
+        db_cursor.execute(
+            """
+        SELECT
+            p.title,
+            p.publication_date,
+            p.image_url,
+            p.content,
+            p.approved
+        FROM Posts p;
+        """
+        )
+        query_results = db_cursor.fetchall()
+
+        # Initialize an empty list and then add each dictionary to it
+        posts = []
+        for row in query_results:
+            post = {
+                'title': row['title'],
+                'publication_date': row['publication_date'],
+                'image_url': row['image_url'],
+                'content': row['content'],
+                'approved': row['approved']
+            }
+            posts.append(post)
+
+        # Serialize Python list to JSON encoded string
+        serialized_posts = json.dumps(posts)
+
+    return serialized_posts
+
+
+def get_single_post(pk):
+    # Open a connection to the database
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        # Write the SQL query to get the information you want
+        db_cursor.execute(
+            """
+        SELECT
+            p.id,
+            p.title,
+            p.publication_date,
+            p.image_url,
+            p.content,
+            p.approved
+        FROM Posts p
+        WHERE p.id = ?;
+        """,
+            (pk,),
+        )
+        query_result = db_cursor.fetchone()
+
+        # Serialize Python list to JSON encoded string
+        serialized_order = json.dumps(dict(query_result))
+
+    return serialized_order


### PR DESCRIPTION
This commit completes the ticket for viewing all post and getting a singular post with all the required information. I created a couple of post and users to test our API.
To test this you'll go to postman, do a get request with the URL http://localhost:8088/posts to get all post. This is the expected output :
[
{
"title": "First Post",
"publication_date": "2024-02-15",
"image_url": "https://example.com/image1.jpg",
"content": "This is the content of the first post.",
"approved": 1
},
{
"title": "Second Post",
"publication_date": "2024-02-16",
"image_url": "https://example.com/image2.jpg",
"content": "This is the content of the second post.",
"approved": 1
}
]
Next you'll test getting a singular post by using the URL http://localhost:8088/posts/1 & http://localhost:8088/posts/2 to get each individual post. The expected output should look like this:
For URL /1:
{
"id": 1,
"title": "First Post",
"publication_date": "2024-02-15",
"image_url": "https://example.com/image1.jpg",
"content": "This is the content of the first post.",
"approved": 1,
"author_display_name": "john_doe"
}
For URL /2:
{
"id": 2,
"title": "Second Post",
"publication_date": "2024-02-16",
"image_url": "https://example.com/image2.jpg",
"content": "This is the content of the second post.",
"approved": 1,
"author_display_name": "jane_smith"
}