### PR TITLE
Added function to retrieve comments by post id

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -25,6 +25,7 @@ from views import (
     get_all_tags,
     delete_tag,
     update_tag,
+    get_comments_by_post_id,
 )
 
 
@@ -99,6 +100,11 @@ class JSONServer(HandleRequests):
         if url["requested_resource"] == "categories":
             response_body = get_all_categories()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+        if url["requested_resource"] == "comments":
+            if url["pk"] != 0:
+                response_body = get_comments_by_post_id(url["pk"])
+                return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
         return self.response(
             "404", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -130,4 +130,10 @@ VALUES
 (2, 2, 'Title of Post 2', '2024-03-06', 'image2.jpg', 'Content of Post 2', true),
 (1, 1, 'Title of Post 3', '2024-03-06', 'image3.jpg', 'Content of Post 3', false);
 
-INSERT INTO Comments (post_id, author_id, content, created_on) VALUES (2, 1, 'Interesting read.', DATETIME('now'));
+INSERT INTO Comments (post_id, author_id, content, created_on) 
+VALUES 
+(1, 4, 'Interesting read.', DATETIME('now')), 
+(1, 5, 'Great post!', DATETIME('now', '-2 day')), 
+(2, 1, 'Nice!', DATETIME('now', '-1 day')), 
+(2, 2, 'Loved this!', DATETIME('now', '-3 day')), 
+(3, 3, 'Why?', DATETIME('now', '-1 day'));

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -22,5 +22,5 @@ from .category import (
 )
 
 from .tag import create_tag, get_tags_by_post_id, get_all_tags, delete_tag, update_tag
-from .comment import create_comment
+from .comment import create_comment, get_comments_by_post_id
 from .postTags import create_post_tags

--- a/views/comment.py
+++ b/views/comment.py
@@ -34,3 +34,56 @@ def create_comment(comment):
         id = db_cursor.lastrowid
 
         return json.dumps({"token": id, "valid": True})
+
+
+def get_comments_by_post_id(postId):
+    """Retrieves all comments associated with a postId
+
+    Args:
+        post Id (integer): The unique id of a post
+
+    Returns:
+        a list of comment instances
+    """
+
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            SELECT
+                id,
+                content,
+                created_on,
+                user
+            FROM (
+                SELECT
+                    c.id AS id,
+                    c.content AS content,
+                    c.created_on AS created_on,
+                    u.username AS user
+                FROM Comments c
+                JOIN Users u 
+                ON u.id = c.author_id
+                WHERE c.post_id = ?
+            ) AS subquery
+            ORDER BY created_on DESC;
+            """,
+            (postId,),
+        )
+        query_results = db_cursor.fetchall()
+
+        comments = []
+        for row in query_results:
+            comment = {
+                "id": row["id"],
+                "content": row["content"],
+                "created_on": row["created_on"],
+                "user": row["user"],
+            }
+            comments.append(comment)
+
+        serialized_comments = json.dumps(comments)
+
+    return serialized_comments


### PR DESCRIPTION
Added function to retrieve comments by post id and added insert statements to fill Comments table.
If a user wants to view the comments of a certain post, the function will retrieve them and order them by most recent first.

TESTING:
1. Run insert statements for Comments in loaddata.sql
2. Run the API
3. Run a GET request in Postman with this url: http://localhost:8088/comments/1
4. Check to see if you received a 200 OK message and the list of comments ordered by most recent first
Example:
[
    {
        "id": 6,
        "content": "Awesome!",
        "created_on": "2024-03-14T11:58:56.390958",
        "user": "john_doe"
    },
    {
        "id": 1,
        "content": "Interesting read.",
        "created_on": "2024-03-14 15:46:13",
        "user": "emma_brown"
    },
    {
        "id": 2,
        "content": "Great post!",
        "created_on": "2024-03-12 15:46:13",
        "user": "david_w"
    }
]