### PR TITLE
Feature/filter posts by category

### DIFF
--- a/views/post.py
+++ b/views/post.py
@@ -135,13 +135,16 @@ def get_all_posts_with_user_and_category():
 
         posts = []
         for row in query_results:
+            category = {
+                "category_id": row["category_id"],
+                "category": row["category_name"],
+            }
             post = {
                 "id": row["id"],
                 "title": row["title"],
                 "author": row["author_username"],
-                "category_id": row["category_id"],
-                "category": row["category_name"],
                 "content": row["content"],
+                "category": category,
             }
             posts.append(post)
 

--- a/views/post.py
+++ b/views/post.py
@@ -124,6 +124,7 @@ def get_all_posts_with_user_and_category():
                 p.content,
                 p.approved,
                 u.username AS author_username,
+                c.id AS category_id,
                 c.label AS category_name
             FROM Posts p
             LEFT JOIN Users u ON p.user_id = u.id
@@ -138,6 +139,7 @@ def get_all_posts_with_user_and_category():
                 "id": row["id"],
                 "title": row["title"],
                 "author": row["author_username"],
+                "category_id": row["category_id"],
                 "category": row["category_name"],
                 "content": row["content"],
             }
@@ -205,6 +207,7 @@ def create_post(post):
         id = db_cursor.lastrowid
 
         return json.dumps({"id": id})
+
 
 def update_post(post):
     """Updates a post in the database


### PR DESCRIPTION
Edited the get_all_posts_with_user_and_category function to return category_id and fixed formatting of return for readability and to know that category_name is from an expand.

TESTING:

1. Create a GET request in Postman with this url: http://localhost:8088/posts?_expand=users&_expand=categories
2. Ensure API is running
3. Check if you received a 200 OK message.
4. Results should look similar to this:
[
    {
        "id": 1,
        "title": "First Post",
        "author": "john_doe",
        "content": "This is the content of the first post.",
        "category": {
            "category_id": 1,
            "category": "hello world"
        }
    },
    {
        "id": 2,
        "title": "Second Post",
        "author": "alice_smith",
        "content": "This is the content of the second post.",
        "category": {
            "category_id": 2,
            "category": "News"
        }
    },
    {
        "id": 5,
        "title": "Franklin The Turtle",
        "author": "john_doe",
        "content": "Goes to the creek.",
        "category": {
            "category_id": 2,
            "category": "News"
        }
    }
]